### PR TITLE
fix: close the Scorecard findings worth closing, and name the ones that will not

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -37,8 +37,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-suffix: audit
@@ -51,6 +51,6 @@ jobs:
             --no-hashes -o /tmp/resolved.txt
           wc -l < /tmp/resolved.txt
       - name: audit it
-        uses: pypa/gh-action-pip-audit@v1.1.0
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
         with:
           inputs: /tmp/resolved.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ on:
     branches: [main]
   pull_request:
 
+# The default `GITHUB_TOKEN` is write-scoped unless a workflow says otherwise, so
+# every job here would be able to push to this repository for no reason. Declared
+# read-only at the top; the one job that needs more says so itself.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -29,11 +35,11 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # hatch-vcs derives the version from tags, which needs history.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -110,10 +116,10 @@ jobs:
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -179,10 +185,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -213,10 +219,10 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -241,10 +247,10 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -260,13 +266,13 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: gitleaks
         # The pre-commit hook covers local commits; a fork's PR never runs it,
         # so CI has to.
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -278,7 +284,7 @@ jobs:
     # there is nothing to compare on a push to `main`.
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: what this change introduces
         # The gap Dependabot leaves. Dependabot reacts once an advisory exists
         # for something already merged; this asks whether *this change* adds a
@@ -291,7 +297,7 @@ jobs:
         # Apache-2.0 says what rebasis promises; a GPL dependency arriving through
         # a transitive bump would quietly withdraw that promise, and a legal
         # review finding it is far more expensive than this job finding it.
-        uses: actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,26 +79,6 @@ jobs:
             echo "::error::docs/reference is stale. Run 'just docs-gen' and commit."
             exit 1
           }
-      - name: the release tooling can still work out a version
-        # The release path used to resolve `python-semantic-release` fresh on
-        # every run, outside `uv.lock`. GitPython 3.1.60 removed an attribute it
-        # reads, and the release workflow broke on a repository where nothing had
-        # changed — with no warning until somebody tried to cut a release.
-        #
-        # It is in the lock now, so that cannot happen from an upload alone. This
-        # step is the other half: it makes the *upgrade* visible on the pull
-        # request that proposes it, rather than at the moment a release is
-        # wanted. Ten seconds, and it exercises exactly what the release job's
-        # first step does.
-        run: |
-          version=$(uv run --group release semantic-release version --print)
-          tag=$(uv run --group release semantic-release version --print-tag)
-          if [ -z "$version" ] || [ -z "$tag" ]; then
-            echo "::error::the release tooling printed no version"
-            exit 1
-          fi
-          echo "next release would be $version ($tag)"
-
       - name: every arXiv citation names its paper
         # The offline half: that `docs/citations.toml` and the committed
         # documentation name the same set of papers. It touches no network, so it
@@ -106,6 +86,38 @@ jobs:
         # citation check is safe to put on the merge path at all. Whether the
         # recorded titles are *true* is the weekly `citations` job's question.
         run: uv run python tools/check_citations.py
+
+      - name: the release tooling can still work out a version
+        # The release path used to resolve `python-semantic-release` fresh on
+        # every run, outside `uv.lock`. GitPython 3.1.60 removed an attribute it
+        # reads, and the release workflow broke on a repository where nothing had
+        # changed — with no warning until somebody tried to cut a release. It is
+        # in the lock now; this step makes the *upgrade* visible on the pull
+        # request that proposes it rather than at the moment a release is wanted.
+        #
+        # **The branch dance is not optional.** On a pull request
+        # `actions/checkout` leaves a detached HEAD at the merge commit, and
+        # python-semantic-release refuses to match a release group in that state:
+        # "Detached HEAD state cannot match any release groups". Pointing a local
+        # `main` at that commit is not a workaround — the merge commit is exactly
+        # what `main` would become, which is the state worth testing. On a push
+        # to `main` HEAD is already on a branch and nothing happens.
+        #
+        # It is `version --print` and not `--version`, and that was measured
+        # rather than assumed: against the broken GitPython, `--version` exits 0
+        # and would have caught nothing, while `version --print` exits 1.
+        run: |
+          git symbolic-ref -q HEAD >/dev/null || {
+            git branch -f main HEAD
+            git switch -q main
+          }
+          version=$(uv run --group release semantic-release version --print)
+          tag=$(uv run --group release semantic-release version --print-tag)
+          if [ -z "$version" ] || [ -z "$tag" ]; then
+            echo "::error::the release tooling printed no version"
+            exit 1
+          fi
+          echo "next release would be $version ($tag)"
 
   # The only job that runs the suite. It was two — a `tests` job and this one
   # — running very nearly the same tests twice, for fourteen minutes of runner

--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -40,8 +40,8 @@ jobs:
       # No `fetch-depth: 0`: nothing here derives a version from tags, and the
       # file list comes from `git ls-files`, which reads the index — a shallow
       # checkout has that in full.
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         # No cache to key: this job installs nothing.
       - name: every recorded title is the title arXiv carries
         # `--no-project`, and it is not a shortcut: the check is stdlib only, so

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+# CodeQL — the dataflow half of the static analysis.
+#
+# `ruff` already runs with every rule enabled, which includes flake8-bandit's
+# security lints. Those are pattern checks: they see a dangerous call at the
+# place it is written. CodeQL follows values through the program, so it sees the
+# untrusted input three functions away from the call that consumes it — which is
+# the class of finding a linter structurally cannot produce.
+#
+# It is also the check OpenSSF Scorecard means by SAST, which scored 0 here while
+# the repository had a security linter on every rule. Worth having for the
+# analysis; the score is a side effect.
+#
+# Python needs no build: `build-mode: none` tells CodeQL to read the source
+# rather than watch a compiler. Free on a public repository — Advanced Security
+# is only required for private repositories in an organisation.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly. A query pack update can surface a finding on code that has not
+    # changed, and a scheduled run is the only thing that would notice.
+    - cron: "36 4 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze python
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      # Writes the findings to the Security tab. Nothing else is needed: the
+      # analysis reads the checkout and talks to no other part of the repository.
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: initialise
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: python
+          build-mode: none
+          # `security-and-quality` over the default set. The default is tuned to
+          # keep noise low on a large codebase; this one is 28,000 lines with a
+          # coverage floor, and the extra queries are affordable.
+          queries: security-and-quality
+      - name: analyse
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # hatch-vcs derives the version from tags, and the site shows it.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -41,7 +41,7 @@ jobs:
         run: uv run python -m rebasis.report.catalog --out docs/reference
       - name: build
         run: uv run --group docs mkdocs build
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
 
@@ -53,4 +53,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           # Distinct per job: parallel jobs sharing one key raced to
@@ -122,10 +122,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-suffix: build
@@ -149,10 +149,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-suffix: plan
@@ -188,10 +188,10 @@ jobs:
       # the permission is what makes that a property rather than a promise.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-suffix: rehearse
@@ -233,7 +233,7 @@ jobs:
             -o "sbom/rebasis-${{ steps.version.outputs.next }}.cdx.json"
           python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(len(d['components']), 'components')" \
             "sbom/rebasis-${{ steps.version.outputs.next }}.cdx.json"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: sbom/
@@ -243,7 +243,7 @@ jobs:
         # thing to want, and TestPyPI refuses a re-upload. Skipping is the right
         # answer there and would be the wrong one on PyPI, which is why only this
         # job sets it.
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -269,11 +269,11 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           cache-suffix: release
@@ -366,7 +366,7 @@ jobs:
         # with it. There is no long-lived secret to leak. The action has produced
         # a PEP 740 attestation by default since v1.11.0, so the published files
         # carry one without further configuration.
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
       - name: the release notes
         run: |
           {

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,13 +6,19 @@
 # security-conscious team assessing whether to depend on rebasis gets a number
 # from a third party instead of a paragraph from the person who wrote the code.
 #
-# Two of the checks this repository cannot pass, and pretending otherwise would
+# Some of its checks this repository cannot pass, and pretending otherwise would
 # be worse than the low score. **Code-Review** counts pull requests reviewed by
 # somebody other than their author; there is one maintainer, so it is low by
 # construction. **Branch-Protection** reads settings this workflow cannot set,
 # and the release workflow pushes the changelog commit and the tag to `main`, so
-# a protection rule has to be written to allow that or a release cannot happen.
-# Both are stated in SECURITY.md rather than worked around.
+# a rule has to be written to allow that or a release cannot happen.
+# **Fuzzing** has none, and **CII-Best-Practices** wants a badge nobody has
+# applied for. Those are stated in SECURITY.md rather than worked around.
+#
+# The ones it *did* find were worth having. Every action in every workflow is now
+# pinned by commit SHA rather than by tag — a tag can be moved to point at other
+# code, a SHA cannot — every workflow declares a read-only default token, and
+# `codeql.yml` adds the dataflow analysis its SAST check was asking for.
 #
 # `publish_results: true` is what makes the badge and the public API entry work.
 # It publishes the score, not the code — the analysis runs entirely on this
@@ -48,25 +54,25 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Scorecard reads the repository through the API, not through a
           # credentialed clone. Withholding the credential is one of the things
           # its own Dangerous-Workflow check looks for.
           persist-credentials: false
       - name: run the checks
-        uses: ossf/scorecard-action@v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
       - name: keep the SARIF where a failure can be read
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
       - name: upload to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 .env
 .env.local
 .env.*.local
+# Working rules for Claude Code in this repository. Local only: it records the
+# maintainer's own process, the GPU host's habits and what has gone wrong here,
+# none of which belongs in a public clone.
+CLAUDE.md
+
 docs/_local/
 *.pem
 *.ppk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,17 +57,19 @@ repos:
   # ── local hooks ──────────────────────────────────────────────────────
   - repo: local
     hooks:
-      # The design document is never committed: it carries real host details.
-      # .gitignore blocks both copies; this hook also blocks `git add -f`.
+      # Two files are never committed: the design document, which carries real
+      # host details, and CLAUDE.md, which records the maintainer's own process
+      # and what has gone wrong in this repository. `.gitignore` blocks both;
+      # this hook also blocks `git add -f`, which `.gitignore` cannot.
       - id: no-design-doc
-        name: the design document must not be committed
+        name: the local-only files must not be committed
         # A block scalar, not a plain one. The plain form was invalid YAML: the
         # `: ` inside `echo "ERROR: ..."` reads as a mapping, so pre-commit
         # could not load this file at all and *every* hook below was silently
         # inert — including gitleaks. Folded style has no such trap.
         entry: >-
-          bash -c 'if git diff --cached --name-only | grep -qE "^docs/(_local|design)/";
-          then echo "ERROR: the design document is local-only and must not be committed";
+          bash -c 'if git diff --cached --name-only | grep -qE "^(docs/(_local|design)/|CLAUDE.md$)";
+          then echo "ERROR: that file is local-only and must not be committed";
           exit 1; fi'
         language: system
         pass_filenames: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,6 +99,43 @@ local attacker. Claiming otherwise would be false.
 
 While the project is 0.x, only the latest release receives fixes.
 
+## Known advisories in the dependency tree
+
+Two packages in the resolved tree carry open advisories with **no fixed version
+upstream**, so neither is closed by an upgrade. Both were assessed against how
+rebasis actually uses them rather than dismissed, and the reasoning is here so a
+reviewer does not have to repeat it.
+
+**chromadb — four advisories, none reachable through rebasis.**
+
+| | |
+|---|---|
+| [PYSEC-2026-311](https://osv.dev/PYSEC-2026-311) | Pre-authentication code injection via the `/api/v2/tenants/{tenant}/databases/{db}/collections` endpoint |
+| [GHSA-36p7-vc44-83pf](https://osv.dev/GHSA-36p7-vc44-83pf) | Authenticated code injection via the collection-update endpoint |
+| [GHSA-2wm9-hf6c-p5cr](https://osv.dev/GHSA-2wm9-hf6c-p5cr) | Missing authorisation validation across tenants |
+| [GHSA-xph7-9rjv-w5fr](https://osv.dev/GHSA-xph7-9rjv-w5fr) | `SimpleRBACAuthorizationProvider` ignores which tenant a permission applies to |
+
+All four are properties of the **Chroma server** — its HTTP API, its
+authentication and its authorisation providers. rebasis opens
+`chromadb.PersistentClient(path=...)` and nothing else: there is no `HttpClient`
+in the backend and the Chroma URI carries no host, so rebasis cannot connect to a
+Chroma server at all, with or without these bugs.
+
+That is a statement about rebasis, not about your deployment. **If you run a
+Chroma server, these advisories apply to it** and rebasis is not what protects
+you from them.
+
+**diskcache — [PYSEC-2026-2447](https://osv.dev/PYSEC-2026-2447), unsafe pickle
+deserialization.** It arrives through `llama-cpp-python`, an optional extra
+deliberately left out of `rebasis[all]` because it compiles from source. The
+attack requires write access to the cache directory, which is already local
+compromise: an attacker who can write there can write to the rest of your
+environment too. Not installing that extra removes the package.
+
+Re-checked weekly by the `Audit` workflow, which runs `pip-audit` over the tree
+`uv.lock` resolves with every extra. When a fix is published, the upgrade is a
+lockfile change.
+
 ## Regulatory scope
 
 Written down because a compliance reviewer would otherwise have to work it out,

--- a/changelog.d/+advisory-assessment.docs.md
+++ b/changelog.d/+advisory-assessment.docs.md
@@ -1,0 +1,9 @@
+`SECURITY.md` says what the open advisories in the dependency tree are, and why neither is reachable through rebasis.
+
+Five, in two packages, and none of them has a fixed version upstream — so neither is closed by an upgrade, and a reviewer who finds them needs the assessment rather than a promise to bump something.
+
+**chromadb carries four**, all of them properties of the Chroma *server*: pre-authentication code injection through its collections endpoint, an authenticated variant of the same, missing authorisation validation across tenants, and an RBAC provider that never checks which tenant a permission applies to. rebasis opens `chromadb.PersistentClient(path=...)` and nothing else — there is no `HttpClient` in the backend and the Chroma URI carries no host — so it cannot reach a Chroma server at all. That is a statement about rebasis and not about your deployment: if you run a Chroma server, those advisories apply to it.
+
+**diskcache carries one**, unsafe pickle deserialization, and arrives through `llama-cpp-python` — an optional extra deliberately outside `rebasis[all]` because it compiles from source. The attack needs write access to the cache directory, which is already local compromise.
+
+Both are re-checked weekly by the `Audit` workflow, over the tree `uv.lock` actually resolves with every extra installed.

--- a/changelog.d/+pinned-actions.fixed.md
+++ b/changelog.d/+pinned-actions.fixed.md
@@ -1,0 +1,9 @@
+Every GitHub Action in every workflow is pinned by commit SHA instead of by tag, and every workflow declares a read-only default token.
+
+A tag is a mutable pointer. `actions/checkout@v7` is whatever the `v7` tag names *today*, and whoever can move that tag can run their code in this repository's CI — with whatever permissions the workflow granted. A commit SHA cannot be moved. The tag stays beside each pin as a comment so a reader can still see what version it is, and Dependabot updates both together.
+
+Forty of the forty-nine findings OpenSSF Scorecard reported were this, across seven workflow files. Two more were the token: GitHub's default `GITHUB_TOKEN` is write-scoped unless a workflow says otherwise, so `ci.yml` and `gpu-tests.yml` were granting every job write access to this repository for no reason. Both now declare `contents: read` at the top, and the jobs that need more say so themselves — the release job's `contents: write`, the Scorecard and CodeQL jobs' `security-events: write`.
+
+`codeql.yml` is new, and answers the SAST finding with something worth having rather than with a checkbox. `ruff` already runs every rule, which includes flake8-bandit's security lints — but those are pattern checks that see a dangerous call where it is written. CodeQL follows values through the program, so it sees the untrusted input three functions away from the call that consumes it, which a linter structurally cannot. Python needs no build step; it runs on every pull request and weekly, because a query-pack update can surface a finding on code that has not changed.
+
+The findings this repository cannot close are named in `SECURITY.md` rather than worked around: Code-Review counts pull requests reviewed by somebody other than their author and there is one maintainer, Branch-Protection is a setting that would block the release workflow's own push until a rule allows it, Fuzzing has none, and CII-Best-Practices wants a badge nobody has applied for.

--- a/changelog.d/+release-tooling-in-the-lock.fixed.md
+++ b/changelog.d/+release-tooling-in-the-lock.fixed.md
@@ -7,3 +7,7 @@ The release tooling is in `uv.lock` instead of being resolved fresh on every run
 `ci.yml` gains the other half: a ten-second step on every pull request that asks the tooling to work out a version and fails if it cannot. The breakage was invisible until somebody wanted a release; now it is visible on the change that introduces it.
 
 Found by `mode: dry-run`, which is what that mode is for — it printed the error and stopped, having touched nothing.
+
+`ci.yml`'s own first attempt at that check then failed for a second, unrelated reason, and the fix is worth recording because it is not a workaround. On a pull request `actions/checkout` leaves a **detached HEAD** at the merge commit, and python-semantic-release refuses to match a release group there — "Detached HEAD state cannot match any release groups". The step now points a local `main` at that commit before asking: the merge commit is exactly what `main` would become, which is the state the check is about.
+
+It uses `version --print` rather than `--version`, and that was measured rather than assumed. Against the GitPython that broke the release path, `--version` exits 0 and would have caught nothing; `version --print` exits 1.


### PR DESCRIPTION
OpenSSF Scorecard reported **49 findings**. Forty-two are closed here. The rest do
not close by configuring anything, and `SECURITY.md` says so rather than a number
obtained by disabling what produced it.

| Finding | Count | |
|---|---|---|
| Pinned-Dependencies | 40 | ✅ every action pinned by SHA |
| Token-Permissions | 2 | ✅ read-only default, scoped per job |
| SAST | 1 | ✅ CodeQL |
| Vulnerabilities | 1 (5 advisories) | ✅ assessed — none reachable, none fixable upstream |
| Branch-Protection | 1 | repository setting; see below |
| Code-Review | 1 | one maintainer |
| Maintained | 1 | repository age |
| Fuzzing | 1 | none |
| CII-Best-Practices | 1 | no badge applied for |

## Why pinning matters here

A tag is a mutable pointer. `actions/checkout@v7` is whatever the `v7` tag names
*today*, and whoever can move that tag runs their code in this repository's CI
with whatever permissions the workflow granted. A SHA cannot be moved.

The tag stays beside each pin as a comment, so a reader still sees the version
and Dependabot updates both together. The count maps exactly onto the tracked
workflows — 14 in `ci.yml`, 13 in `release.yml`, 4 each in `scorecard.yml` and
`docs.yml`, 3 in `audit.yml`, 2 in `citations.yml` — and no unpinned `uses:`
remains in any of the eight.

## The token

`GITHUB_TOKEN` is write-scoped unless a workflow says otherwise, so every job in
`ci.yml` could push to this repository for no reason. `contents: read` at the
top; the jobs that need more say so themselves.

## CodeQL is not a checkbox

`ruff` runs every rule, which includes flake8-bandit's security lints. Those are
pattern checks: they see a dangerous call where it is written. CodeQL follows
values through the program, so it sees the untrusted input three functions away
from the call that consumes it — the class of finding a linter structurally
cannot produce. `build-mode: none` because Python needs no build; weekly as well
as per-PR, because a query-pack update can surface a finding on code that has not
changed.

## The five advisories, assessed rather than deferred

**None has a fixed version upstream**, so none closes by an upgrade. Four are in
chromadb and all four are properties of the Chroma **server** — its HTTP API
(`/api/v2/tenants/…/collections`), its authentication, its
`SimpleRBACAuthorizationProvider`. rebasis opens
`chromadb.PersistentClient(path=…)` and nothing else: there is no `HttpClient` in
the backend and the Chroma URI carries no host, so it cannot connect to a Chroma
server at all. That is a statement about rebasis, not about anyone's deployment,
and `SECURITY.md` says so.

The fifth is diskcache's unsafe pickle deserialization, arriving through
`llama-cpp-python` — an extra deliberately outside `rebasis[all]` because it
compiles from source — and it needs write access to the cache directory, which is
already local compromise.

Both are re-checked weekly by the `Audit` workflow over the tree `uv.lock`
resolves with every extra.

## What is left, and why it stays

- **Branch-Protection** — a repository setting, and turning it on naively blocks
  the release workflow, which pushes the changelog commit and the tag to `main`.
  A rule has to allow that first. Sequence: release 0.1.0, then protect.
- **Code-Review** — counts pull requests reviewed by somebody other than their
  author. One maintainer; no configuration changes that.
- **Maintained, Fuzzing, CII-Best-Practices** — repository age, no fuzz targets,
  no badge applied for.

A low score with a stated reason is more useful to an evaluator than a high one
obtained by turning off the check.

## Also here

Two merged branches deleted — `feat/evidence-and-gaps` (no commits outside
`main`) and `feat/cascade-and-migration-safety` (14 commits, all reported by
`git cherry` as already equivalent in `main`). Checked before deleting rather
than assumed from the diff.

## Verified

All eight workflow files parse. No unpinned `uses:` remains. Every SHA was
resolved through `gh api repos/…/git/ref/…` and dereferenced where the tag was
annotated; the ones that overlap with the upstream Scorecard example match it
exactly. `ruff`, `mypy --strict`, the layer contract, the citation check and
`mkdocs --strict` all pass.

No Python changed, so the suite was not re-run for this branch; it runs on the
GPU host and passed there at 1,427 for the commit this branches from.
